### PR TITLE
feat(upgrade): upgrade workflow expressions

### DIFF
--- a/src/main/java/io/zeebe/upgrade/workflow/UpgradeWorkflows.java
+++ b/src/main/java/io/zeebe/upgrade/workflow/UpgradeWorkflows.java
@@ -1,0 +1,105 @@
+package io.zeebe.upgrade.workflow;
+
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.FileVisitOption;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public final class UpgradeWorkflows {
+
+  public static final String BPMN_FILE_EXTENSION = ".bpmn";
+  public static final String BPMN_XML_FILE_EXTENSION = ".bpmn20.xml";
+
+  public static void main(String[] args) throws IOException {
+    if (args.length != 2) {
+      System.err.printf("Invalid arguments: %s\n", Arrays.toString(args));
+      System.err.println("Expected 2 arguments: <source-directory>  <target-directory>");
+      System.err.println("\t<source-directory> - the directory to read the BPMN files from");
+      System.err.println(
+          "\t<target-directory> - the directory to write the upgraded BPMN files to");
+      System.exit(1);
+    }
+
+    final String sourceDir = args[0];
+    final String targetDir = args[1];
+
+    final var sourcePath = Paths.get(sourceDir);
+    final var targetPath = Paths.get(targetDir);
+
+    validatePath(sourcePath);
+
+    targetPath.toFile().mkdirs();
+
+    System.out.printf(
+        "Upgrade workflows from directory '%s' to '%s'\n",
+        sourcePath.toAbsolutePath(), targetPath.toAbsolutePath());
+
+    upgradeWorkflows(sourcePath, targetPath);
+  }
+
+  private static void upgradeWorkflows(final Path sourcePath, final Path targetPath)
+      throws IOException {
+    final AtomicInteger updatedWorkflows = new AtomicInteger();
+
+    Files.walk(sourcePath, FileVisitOption.FOLLOW_LINKS)
+        .filter(UpgradeWorkflows::isBpmnFile)
+        .peek(path -> System.out.printf("> Upgrade BPMN file '%s'\n", path.toAbsolutePath()))
+        .forEach(
+            path -> {
+              final var workflow = readBpmnFile(path);
+              final var upgradedWorkflow = WorkflowExpressionUpgrade.upgradeWorkflow(workflow);
+
+              final var relativePath = sourcePath.relativize(path);
+              final var target = targetPath.resolve(relativePath);
+
+              writeWorkflow(upgradedWorkflow, target);
+
+              updatedWorkflows.incrementAndGet();
+            });
+
+    System.out.printf("Done. Upgraded %d workflows.\n", updatedWorkflows.get());
+  }
+
+  private static void writeWorkflow(final BpmnModelInstance upgradedWorkflow, final Path target) {
+    try {
+      final OutputStream outputStream = Files.newOutputStream(target);
+      Bpmn.writeModelToStream(outputStream, upgradedWorkflow);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private static BpmnModelInstance readBpmnFile(Path path) {
+    return Bpmn.readModelFromFile(path.toFile());
+  }
+
+  private static boolean isBpmnFile(Path path) {
+    final var file = path.toFile();
+    if (file.isFile()) {
+      final var fileName = file.getName();
+      final var normalized = fileName.toLowerCase();
+      return normalized.endsWith(BPMN_FILE_EXTENSION)
+          || normalized.endsWith(BPMN_XML_FILE_EXTENSION);
+    } else {
+      return false;
+    }
+  }
+
+  private static void validatePath(final Path path) {
+    if (!path.toFile().exists()) {
+      System.err.printf("The given path '%s' doesn't exist.\n", path.toAbsolutePath());
+      System.exit(1);
+    }
+
+    if (!path.toFile().isDirectory()) {
+      System.err.printf("The given path '%s' is no directory.\n", path.toAbsolutePath());
+      System.exit(1);
+    }
+  }
+}

--- a/src/main/java/io/zeebe/upgrade/workflow/WorkflowExpressionUpgrade.java
+++ b/src/main/java/io/zeebe/upgrade/workflow/WorkflowExpressionUpgrade.java
@@ -1,0 +1,151 @@
+package io.zeebe.upgrade.workflow;
+
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.zeebe.model.bpmn.instance.ConditionExpression;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeIoMapping;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeLoopCharacteristics;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeSubscription;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
+
+public final class WorkflowExpressionUpgrade {
+
+  private static final String EXPRESSION_PREFIX = "=";
+
+  public static BpmnModelInstance upgradeWorkflow(final BpmnModelInstance workflow) {
+    final var targetWorkflow = workflow.clone();
+
+    targetWorkflow
+        .getModelElementsByType(ConditionExpression.class)
+        .forEach(WorkflowExpressionUpgrade::upgradeConditionExpression);
+
+    targetWorkflow
+        .getModelElementsByType(ZeebeIoMapping.class)
+        .forEach(WorkflowExpressionUpgrade::upgradeVariableMappingExpression);
+
+    targetWorkflow
+        .getModelElementsByType(ZeebeSubscription.class)
+        .forEach(WorkflowExpressionUpgrade::upgradeMessageSubscription);
+
+    targetWorkflow
+        .getModelElementsByType(ZeebeLoopCharacteristics.class)
+        .forEach(WorkflowExpressionUpgrade::upgradeMultiInstance);
+
+    return targetWorkflow;
+  }
+
+  private static void upgradeVariableMappingExpression(final ZeebeIoMapping mapping) {
+    mapping
+        .getInputs()
+        .forEach(
+            input ->
+                migrateExpression(
+                    input::getSource,
+                    input::setSource,
+                    logChange(input, "source of input mapping")));
+
+    mapping
+        .getOutputs()
+        .forEach(
+            output ->
+                migrateExpression(
+                    output::getSource,
+                    output::setSource,
+                    logChange(output, "source of output mapping")));
+  }
+
+  private static void upgradeMessageSubscription(final ZeebeSubscription subscription) {
+    migrateExpression(
+        subscription::getCorrelationKey,
+        subscription::setCorrelationKey,
+        logChange(subscription, "correlation key"));
+  }
+
+  private static void upgradeMultiInstance(final ZeebeLoopCharacteristics loopCharacteristics) {
+    migrateExpression(
+        loopCharacteristics::getInputCollection,
+        loopCharacteristics::setInputCollection,
+        logChange(loopCharacteristics, "multi-instance input collection"));
+
+    migrateExpression(
+        loopCharacteristics::getOutputElement,
+        loopCharacteristics::setOutputElement,
+        logChange(loopCharacteristics, "multi-instance output element"));
+  }
+
+  private static void upgradeConditionExpression(final ConditionExpression conditionExpression) {
+    final Function<String, String> expressionPrefix =
+        WorkflowExpressionUpgrade::addExpressionPrefix;
+
+    final Function<String, String> operatorReplacement =
+        expression ->
+            expression.replaceAll("&&", "and").replaceAll("\\|\\|", "or").replaceAll("==", "=");
+
+    migrate(
+        conditionExpression::getTextContent,
+        expressionPrefix.andThen(operatorReplacement),
+        conditionExpression::setTextContent,
+        logChange(conditionExpression, "condition"));
+  }
+
+  private static void migrateExpression(
+      Supplier<String> expressionGetter,
+      Consumer<String> expressionSetter,
+      BiConsumer<String, String> onChange) {
+
+    migrate(
+        expressionGetter,
+        WorkflowExpressionUpgrade::addExpressionPrefix,
+        expressionSetter,
+        onChange);
+  }
+
+  private static void migrate(
+      Supplier<String> expressionGetter,
+      Function<String, String> migrateExpression,
+      Consumer<String> expressionSetter,
+      BiConsumer<String, String> onChange) {
+
+    final var expression = expressionGetter.get();
+    var newExpression = migrateExpression.apply(expression);
+
+    if (!expression.equals(newExpression)) {
+      expressionSetter.accept(newExpression);
+      onChange.accept(expression, newExpression);
+    }
+  }
+
+  private static String addExpressionPrefix(String expression) {
+    if (!expression.startsWith(EXPRESSION_PREFIX)) {
+      return EXPRESSION_PREFIX + expression;
+    } else {
+      return expression;
+    }
+  }
+
+  private static BiConsumer<String, String> logChange(
+      ModelElementInstance elementInstance, String expressionName) {
+    return (before, after) ->
+        System.out.printf(
+            "\t* Migrate %s [id: %s] from '%s' to '%s'\n",
+            expressionName, getElementId(elementInstance), before, after);
+  }
+
+  private static String getElementId(ModelElementInstance elementInstance) {
+    final var id = elementInstance.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID);
+    if (id != null && !id.isEmpty()) {
+      return id;
+    }
+
+    final var parentElement = elementInstance.getParentElement();
+    if (parentElement != null) {
+      return getElementId(parentElement);
+    }
+
+    return "?";
+  }
+}

--- a/src/test/java/io/zeebe/WorkflowExpressionUpgradeTest.java
+++ b/src/test/java/io/zeebe/WorkflowExpressionUpgradeTest.java
@@ -1,0 +1,157 @@
+package io.zeebe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.instance.ConditionExpression;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeLoopCharacteristics;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeOutput;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeSubscription;
+import io.zeebe.upgrade.workflow.UpgradeWorkflows;
+import java.io.File;
+import java.io.IOException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public final class WorkflowExpressionUpgradeTest {
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+
+  private String sourceFolder;
+  private File targetFolder;
+
+  @Before
+  public void init() throws IOException {
+    sourceFolder = getClass().getResource("/workflows").getFile();
+    targetFolder = temp.newFolder("target");
+
+    final var args = new String[] {sourceFolder, targetFolder.toString()};
+    UpgradeWorkflows.main(args);
+  }
+
+  @Test
+  public void conditionExpression() {
+    // given
+    final var sourceFile = new File(sourceFolder, "wf-with-condition.bpmn");
+    final var sourceWorkflow = Bpmn.readModelFromFile(sourceFile);
+
+    assertThat(
+            sourceWorkflow.getModelElementsByType(ConditionExpression.class).stream()
+                .map(ConditionExpression::getTextContent))
+        .hasSize(1)
+        .allSatisfy(
+            condition -> assertThat(condition).doesNotStartWith("=").contains("||", "&&", "=="));
+
+    // then
+    final var targetFile = new File(targetFolder, "wf-with-condition.bpmn");
+    final var targetWorkflow = Bpmn.readModelFromFile(targetFile);
+
+    assertThat(
+            targetWorkflow.getModelElementsByType(ConditionExpression.class).stream()
+                .map(ConditionExpression::getTextContent))
+        .hasSize(1)
+        .allSatisfy(
+            condition ->
+                assertThat(condition)
+                    .startsWith("=")
+                    .contains("or", "and")
+                    .doesNotContain("||", "&&", "=="));
+  }
+
+  @Test
+  public void variableMappingExpression() {
+    // given
+    final var sourceFile = new File(sourceFolder, "wf-with-mappings.bpmn");
+    final var sourceWorkflow = Bpmn.readModelFromFile(sourceFile);
+
+    assertThat(
+            sourceWorkflow.getModelElementsByType(ZeebeInput.class).stream()
+                .map(ZeebeMapping::getSource))
+        .hasSize(2)
+        .allSatisfy(source -> assertThat(source).doesNotStartWith("="));
+
+    assertThat(
+            sourceWorkflow.getModelElementsByType(ZeebeOutput.class).stream()
+                .map(ZeebeMapping::getSource))
+        .hasSize(2)
+        .allSatisfy(source -> assertThat(source).doesNotStartWith("="));
+
+    // then
+    final var targetFile = new File(targetFolder, "wf-with-mappings.bpmn");
+    final var targetWorkflow = Bpmn.readModelFromFile(targetFile);
+
+    assertThat(
+            targetWorkflow.getModelElementsByType(ZeebeInput.class).stream()
+                .map(ZeebeMapping::getSource))
+        .hasSize(2)
+        .allSatisfy(source -> assertThat(source).startsWith("="));
+
+    assertThat(
+            targetWorkflow.getModelElementsByType(ZeebeOutput.class).stream()
+                .map(ZeebeMapping::getSource))
+        .hasSize(2)
+        .allSatisfy(source -> assertThat(source).startsWith("="));
+  }
+
+  @Test
+  public void messageCorrelationKeyExpression() {
+    // given
+    final var sourceFile = new File(sourceFolder, "wf-with-message-correlation-key.bpmn");
+    final var sourceWorkflow = Bpmn.readModelFromFile(sourceFile);
+
+    assertThat(
+            sourceWorkflow.getModelElementsByType(ZeebeSubscription.class).stream()
+                .map(ZeebeSubscription::getCorrelationKey))
+        .hasSize(3)
+        .allSatisfy(correlationKey -> assertThat(correlationKey).doesNotStartWith("="));
+
+    // then
+    final var targetFile = new File(targetFolder, "wf-with-message-correlation-key.bpmn");
+    final var targetWorkflow = Bpmn.readModelFromFile(targetFile);
+
+    assertThat(
+            targetWorkflow.getModelElementsByType(ZeebeSubscription.class).stream()
+                .map(ZeebeSubscription::getCorrelationKey))
+        .hasSize(3)
+        .allSatisfy(correlationKey -> assertThat(correlationKey).startsWith("="));
+  }
+
+  @Test
+  public void multiInstanceExpressions() {
+    // given
+    final var sourceFile = new File(sourceFolder, "wf-with-multi-instance.bpmn");
+    final var sourceWorkflow = Bpmn.readModelFromFile(sourceFile);
+
+    assertThat(
+            sourceWorkflow.getModelElementsByType(ZeebeLoopCharacteristics.class).stream()
+                .map(ZeebeLoopCharacteristics::getInputCollection))
+        .hasSize(2)
+        .allSatisfy(inputCollection -> assertThat(inputCollection).doesNotStartWith("="));
+
+    assertThat(
+            sourceWorkflow.getModelElementsByType(ZeebeLoopCharacteristics.class).stream()
+                .map(ZeebeLoopCharacteristics::getOutputElement))
+        .hasSize(2)
+        .allSatisfy(outputElement -> assertThat(outputElement).doesNotStartWith("="));
+
+    // then
+    final var targetFile = new File(targetFolder, "wf-with-multi-instance.bpmn");
+    final var targetWorkflow = Bpmn.readModelFromFile(targetFile);
+
+    assertThat(
+            targetWorkflow.getModelElementsByType(ZeebeLoopCharacteristics.class).stream()
+                .map(ZeebeLoopCharacteristics::getInputCollection))
+        .hasSize(2)
+        .allSatisfy(inputCollection -> assertThat(inputCollection).startsWith("="));
+
+    assertThat(
+            targetWorkflow.getModelElementsByType(ZeebeLoopCharacteristics.class).stream()
+                .map(ZeebeLoopCharacteristics::getOutputElement))
+        .hasSize(2)
+        .allSatisfy(outputElement -> assertThat(outputElement).startsWith("="));
+  }
+}

--- a/src/test/resources/workflows/wf-with-condition.bpmn
+++ b/src/test/resources/workflows/wf-with-condition.bpmn
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1uvuwcg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.8.0">
+  <bpmn:process id="wf-with-condition" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_189gqdo</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:exclusiveGateway id="ExclusiveGateway_0vi2d9d" default="SequenceFlow_1cyavu8">
+      <bpmn:incoming>SequenceFlow_189gqdo</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1iyxiyr</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_1cyavu8</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_189gqdo" sourceRef="StartEvent_1" targetRef="ExclusiveGateway_0vi2d9d" />
+    <bpmn:sequenceFlow id="SequenceFlow_1iyxiyr" sourceRef="ExclusiveGateway_0vi2d9d" targetRef="Task_0clleh1">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">x &gt; 10 || (x &gt; 5 &amp;&amp; y == "ok")</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="EndEvent_0ex6qyd">
+      <bpmn:incoming>SequenceFlow_1dhuq1d</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1dhuq1d" sourceRef="Task_0clleh1" targetRef="EndEvent_0ex6qyd" />
+    <bpmn:sequenceFlow id="SequenceFlow_1cyavu8" sourceRef="ExclusiveGateway_0vi2d9d" targetRef="Task_137f075" />
+    <bpmn:endEvent id="EndEvent_1jif7fn">
+      <bpmn:incoming>SequenceFlow_1tkikas</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1tkikas" sourceRef="Task_137f075" targetRef="EndEvent_1jif7fn" />
+    <bpmn:serviceTask id="Task_0clleh1" name="A">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="task-a" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1iyxiyr</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1dhuq1d</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Task_137f075" name="B">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="task-b" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1cyavu8</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1tkikas</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="wf-with-condition">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_0vi2d9d_di" bpmnElement="ExclusiveGateway_0vi2d9d" isMarkerVisible="true">
+        <dc:Bounds x="265" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_189gqdo_di" bpmnElement="SequenceFlow_189gqdo">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="265" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1iyxiyr_di" bpmnElement="SequenceFlow_1iyxiyr">
+        <di:waypoint x="315" y="117" />
+        <di:waypoint x="370" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0ex6qyd_di" bpmnElement="EndEvent_0ex6qyd">
+        <dc:Bounds x="532" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1dhuq1d_di" bpmnElement="SequenceFlow_1dhuq1d">
+        <di:waypoint x="470" y="117" />
+        <di:waypoint x="532" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1cyavu8_di" bpmnElement="SequenceFlow_1cyavu8">
+        <di:waypoint x="290" y="142" />
+        <di:waypoint x="290" y="230" />
+        <di:waypoint x="370" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_1jif7fn_di" bpmnElement="EndEvent_1jif7fn">
+        <dc:Bounds x="532" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1tkikas_di" bpmnElement="SequenceFlow_1tkikas">
+        <di:waypoint x="470" y="230" />
+        <di:waypoint x="532" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_0j1l7dz_di" bpmnElement="Task_0clleh1">
+        <dc:Bounds x="370" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_056fq6k_di" bpmnElement="Task_137f075">
+        <dc:Bounds x="370" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/test/resources/workflows/wf-with-mappings.bpmn
+++ b/src/test/resources/workflows/wf-with-mappings.bpmn
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0mv2dsb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.8.0">
+  <bpmn:process id="wf-with-mappings" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1fost9g</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:subProcess id="SubProcess_04gppz5">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="x" target="a" />
+          <zeebe:output source="b" target="y" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1fost9g</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0sr6xpv</bpmn:outgoing>
+      <bpmn:startEvent id="StartEvent_1in6xlg">
+        <bpmn:outgoing>SequenceFlow_0m0lft3</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_0m0lft3" sourceRef="StartEvent_1in6xlg" targetRef="Task_151dcvp" />
+      <bpmn:endEvent id="EndEvent_1mi63bk">
+        <bpmn:incoming>SequenceFlow_1drkqke</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_1drkqke" sourceRef="Task_151dcvp" targetRef="EndEvent_1mi63bk" />
+      <bpmn:serviceTask id="Task_151dcvp" name="A">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="task-a" />
+          <zeebe:ioMapping>
+            <zeebe:input source="x.y" target="a.b" />
+            <zeebe:output source="c.d" target="y.z" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+        <bpmn:incoming>SequenceFlow_0m0lft3</bpmn:incoming>
+        <bpmn:outgoing>SequenceFlow_1drkqke</bpmn:outgoing>
+      </bpmn:serviceTask>
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="SequenceFlow_1fost9g" sourceRef="StartEvent_1" targetRef="SubProcess_04gppz5" />
+    <bpmn:endEvent id="EndEvent_0rheozg">
+      <bpmn:incoming>SequenceFlow_0sr6xpv</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0sr6xpv" sourceRef="SubProcess_04gppz5" targetRef="EndEvent_0rheozg" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="wf-with-mappings">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_04gppz5_di" bpmnElement="SubProcess_04gppz5" isExpanded="true">
+        <dc:Bounds x="280" y="77" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1in6xlg_di" bpmnElement="StartEvent_1in6xlg">
+        <dc:Bounds x="320" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1fost9g_di" bpmnElement="SequenceFlow_1fost9g">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="280" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0m0lft3_di" bpmnElement="SequenceFlow_0m0lft3">
+        <di:waypoint x="356" y="177" />
+        <di:waypoint x="410" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_1mi63bk_di" bpmnElement="EndEvent_1mi63bk">
+        <dc:Bounds x="572" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1drkqke_di" bpmnElement="SequenceFlow_1drkqke">
+        <di:waypoint x="510" y="177" />
+        <di:waypoint x="572" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_1rxznzc_di" bpmnElement="Task_151dcvp">
+        <dc:Bounds x="410" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0rheozg_di" bpmnElement="EndEvent_0rheozg">
+        <dc:Bounds x="702" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0sr6xpv_di" bpmnElement="SequenceFlow_0sr6xpv">
+        <di:waypoint x="630" y="177" />
+        <di:waypoint x="702" y="177" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/test/resources/workflows/wf-with-message-correlation-key.bpmn
+++ b/src/test/resources/workflows/wf-with-message-correlation-key.bpmn
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0pr8khs" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.8.0">
+  <bpmn:process id="wf-with-message-correlation-key" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_07wobcw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_07wobcw" sourceRef="StartEvent_1" targetRef="IntermediateThrowEvent_1vuqba6" />
+    <bpmn:intermediateCatchEvent id="IntermediateThrowEvent_1vuqba6">
+      <bpmn:incoming>SequenceFlow_07wobcw</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_082ctbt</bpmn:outgoing>
+      <bpmn:messageEventDefinition messageRef="Message_0e13xfc" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_082ctbt" sourceRef="IntermediateThrowEvent_1vuqba6" targetRef="Task_0r91xm3" />
+    <bpmn:receiveTask id="Task_0r91xm3" messageRef="Message_03pfeyu">
+      <bpmn:incoming>SequenceFlow_082ctbt</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0613lr7</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:endEvent id="EndEvent_0fqojvy">
+      <bpmn:incoming>SequenceFlow_0613lr7</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0613lr7" sourceRef="Task_0r91xm3" targetRef="EndEvent_0fqojvy" />
+    <bpmn:subProcess id="SubProcess_0bzerfk" triggeredByEvent="true">
+      <bpmn:startEvent id="StartEvent_0nrvfsf">
+        <bpmn:outgoing>SequenceFlow_0hc906x</bpmn:outgoing>
+        <bpmn:messageEventDefinition messageRef="Message_02pvslo" />
+      </bpmn:startEvent>
+      <bpmn:endEvent id="EndEvent_1iv51qh">
+        <bpmn:incoming>SequenceFlow_0hc906x</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_0hc906x" sourceRef="StartEvent_0nrvfsf" targetRef="EndEvent_1iv51qh" />
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmn:message id="Message_0e13xfc" name="message-a">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="x" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_03pfeyu" name="message-b">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="y.z" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_02pvslo" name="message-c">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="z" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="wf-with-message-correlation-key">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_07wobcw_di" bpmnElement="SequenceFlow_07wobcw">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="272" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="IntermediateCatchEvent_15hbyef_di" bpmnElement="IntermediateThrowEvent_1vuqba6">
+        <dc:Bounds x="272" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_082ctbt_di" bpmnElement="SequenceFlow_082ctbt">
+        <di:waypoint x="308" y="117" />
+        <di:waypoint x="370" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ReceiveTask_1mjzh9m_di" bpmnElement="Task_0r91xm3">
+        <dc:Bounds x="370" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0fqojvy_di" bpmnElement="EndEvent_0fqojvy">
+        <dc:Bounds x="532" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0613lr7_di" bpmnElement="SequenceFlow_0613lr7">
+        <di:waypoint x="470" y="117" />
+        <di:waypoint x="532" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="SubProcess_1kcbjzk_di" bpmnElement="SubProcess_0bzerfk" isExpanded="true">
+        <dc:Bounds x="160" y="200" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_0f9sltg_di" bpmnElement="StartEvent_0nrvfsf">
+        <dc:Bounds x="200" y="282" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1iv51qh_di" bpmnElement="EndEvent_1iv51qh">
+        <dc:Bounds x="292" y="282" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0hc906x_di" bpmnElement="SequenceFlow_0hc906x">
+        <di:waypoint x="236" y="300" />
+        <di:waypoint x="292" y="300" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/test/resources/workflows/wf-with-multi-instance.bpmn
+++ b/src/test/resources/workflows/wf-with-multi-instance.bpmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0hm1dex" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.8.0">
+  <bpmn:process id="wf-with-multi-instance" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1aiv3y6</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_1tbbasy">
+      <bpmn:incoming>SequenceFlow_1aiv3y6</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0ml9vsk</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="xs" inputElement="x" outputCollection="rs" outputElement="r" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="SequenceFlow_1aiv3y6" sourceRef="StartEvent_1" targetRef="Task_1tbbasy" />
+    <bpmn:subProcess id="SubProcess_0n1e5a5">
+      <bpmn:incoming>SequenceFlow_0ml9vsk</bpmn:incoming>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="x.ys" inputElement="y" outputCollection="rs" outputElement="y.rs" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:startEvent id="StartEvent_11jo3pp">
+        <bpmn:outgoing>SequenceFlow_14pcv5c</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:endEvent id="EndEvent_04mtdae">
+        <bpmn:incoming>SequenceFlow_14pcv5c</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_14pcv5c" sourceRef="StartEvent_11jo3pp" targetRef="EndEvent_04mtdae" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="SequenceFlow_0ml9vsk" sourceRef="Task_1tbbasy" targetRef="SubProcess_0n1e5a5" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="wf-with-multi-instance">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_1tbbasy_di" bpmnElement="Task_1tbbasy">
+        <dc:Bounds x="270" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1aiv3y6_di" bpmnElement="SequenceFlow_1aiv3y6">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="270" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="SubProcess_0n1e5a5_di" bpmnElement="SubProcess_0n1e5a5" isExpanded="true">
+        <dc:Bounds x="450" y="77" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_11jo3pp_di" bpmnElement="StartEvent_11jo3pp">
+        <dc:Bounds x="490" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0ml9vsk_di" bpmnElement="SequenceFlow_0ml9vsk">
+        <di:waypoint x="370" y="177" />
+        <di:waypoint x="450" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_04mtdae_di" bpmnElement="EndEvent_04mtdae">
+        <dc:Bounds x="582" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_14pcv5c_di" bpmnElement="SequenceFlow_14pcv5c">
+        <di:waypoint x="526" y="177" />
+        <di:waypoint x="582" y="177" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
* small Java program to migrate workflow expressions to Zeebe 0.23.0
* migrate expressions of the following elements
  * conditions 
  * variable mappings
  * correlation keys
  * multi-instance input collection and output element 

Note that this tool is built for this single use case only. It was not a goal to write a general migration tool or that it can be reused later.